### PR TITLE
chore(build-nightly.yml): add support for multiple Java versions (11,…

### DIFF
--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -10,4 +10,5 @@ jobs:
       uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
       with:
         nightly: true
+        java: '[11, 17, 18]'
       secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,3 +12,5 @@ jobs:
   build-test:
     uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.5.5
     secrets: inherit
+    with:
+      java: '[11, 17, 18]'


### PR DESCRIPTION
… 17, 18) in the nightly build workflow

chore(test.yml): add support for multiple Java versions (11, 17, 18) in the test workflow