### PR TITLE
DAT-18926: use @main in build-logic

### DIFF
--- a/.github/workflows/attach-artifact-release.yml
+++ b/.github/workflows/attach-artifact-release.yml
@@ -8,5 +8,5 @@ on:
 jobs:
 
   attach-artifact-to-release:
-    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/extension-attach-artifact-release.yml@main
     secrets: inherit

--- a/.github/workflows/build-nightly.yml
+++ b/.github/workflows/build-nightly.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     nightly-build:
-      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.7.8
+      uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
       with:
         nightly: true
         java: '[11, 17, 18]'

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,5 +7,5 @@ on:
 
 jobs:
   create-release:
-    uses: liquibase/build-logic/.github/workflows/create-release.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/create-release.yml@main
     secrets: inherit

--- a/.github/workflows/release-published.yml
+++ b/.github/workflows/release-published.yml
@@ -11,5 +11,5 @@ permissions:
   
 jobs:
   release:
-    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/extension-release-published.yml@main
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build-test:
-    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@v0.7.8
+    uses: liquibase/build-logic/.github/workflows/os-extension-test.yml@main
     secrets: inherit
     with:
       java: '[11, 17, 18]'


### PR DESCRIPTION
This pull request updates various GitHub workflow files to use the latest version of the workflows from the `liquibase/build-logic` repository. The changes ensure that the workflows are using the `main` branch instead of a specific version.

Updates to GitHub workflow files:

* [`.github/workflows/attach-artifact-release.yml`](diffhunk://#diff-4e6cdd9dccb26ce28aa3716a4046b99dd39c69e9319bf6b4e2922e6309c13b4aL11-R11): Updated to use `extension-attach-artifact-release.yml` from the `main` branch.
* [`.github/workflows/build-nightly.yml`](diffhunk://#diff-9af00ec87e110684f20ae5b6b3bd168ad21793f9dfe9946c9c48587fdd6ef1f6L10-R10): Updated to use `os-extension-test.yml` from the `main` branch.
* [`.github/workflows/create-release.yml`](diffhunk://#diff-8ac33fe295df086d3e55df1eb01194819d34cc0f5f54076dba96ceac0e40bd79L10-R10): Updated to use `create-release.yml` from the `main` branch.
* [`.github/workflows/release-published.yml`](diffhunk://#diff-f7ca0660afb7c5d6e7220dee8a6db81db251b3c98818f4d76a3e4441b85c7a6dL14-R14): Updated to use `extension-release-published.yml` from the `main` branch.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L13-R13): Updated to use `os-extension-test.yml` from the `main` branch.